### PR TITLE
Removed the default data from the POI editor

### DIFF
--- a/js/textEditor.js
+++ b/js/textEditor.js
@@ -127,7 +127,6 @@ function fillEditor(poi){
 		else{
 			$("#spTitle").val("");
 			$("#autoOn").click();
-			//$("#autoOff").click();
 			$("#spBeaconID").val("");     
 			CKEDITOR.instances["editor1"].setData("");
 			$("#attachedDocName").text("");
@@ -140,7 +139,6 @@ function fillEditor(poi){
 				if (currentPOI.storyPoint[p].storylineID == active_id){
 					$("#spTitle").val(currentPOI.storyPoint[p].title);
 					$("#autoOn").click();
-					//$("#autoOff").click();
 					$("#spBeaconID").val(currentPOI.ibeacon);     
 					CKEDITOR.instances["editor1"].setData(currentPOI.storyPoint[p].description);
 					$("#attachedDocName").text(currentPOI.storyPoint[p].media);


### PR DESCRIPTION
This was previously fixed in SVLKI-98, but got lost in a merge
conflict. The issue is now resolved.
