### PR TITLE
Fix for highlighting issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                                 </li>
                                 <li id = "submitButton" onclick="addNewStoryLine()"><a href="#">Submit</a></li>
                                 <li id = "editButton" onclick="editStoryLine()"><a href="#">Edit</a></li>
-                                <li onclick="setCreatePOIid()"><a href="#">Edit a Point of Interest</a></li>
+                                <li id = "editPOIButton" onclick="setCreatePOIid()"><a href="#">Edit a Point of Interest</a></li>
                             </ul>
                         </div>
                         <!-- MAP LAYOUT MENU -->

--- a/js/canvas.js
+++ b/js/canvas.js
@@ -127,7 +127,10 @@ function POI(point) {
 }
 
 function setCreatePOIid(){
+    $("#"+active_id).removeClass("active");
+    $("#editPOIButton").addClass("active");
     active_id = -2;
+    hideInactiveStoryLines();
     redraw();
 }
 

--- a/js/storylines.js
+++ b/js/storylines.js
@@ -111,6 +111,7 @@ function storylineClicked(elem){
     var id = $(elem).attr("id");
     $("#"+active_id).removeClass("active");
     $("#"+id).addClass("active");
+    $("#editPOIButton").removeClass("active");
     active_id = id;
     highlightPOI(active_id);
     hideInactiveStoryLines();


### PR DESCRIPTION
A storyline is highlighted when a POI is being placed. This was fixed.
Also, the edit point of interest gets highlighted when it is active.
