### PR TITLE
Removed pushing the currentPOI.ID when editing a node

### DIFF
--- a/js/textEditor.js
+++ b/js/textEditor.js
@@ -114,12 +114,6 @@ $(document).ready(function(){
                             //Adding the point to the storyline list.
                             //get into <a> and change POIList[val].title
                             $("#"+POIList[val].storyPoint[p].ID+"_a").text(POIList[val].storyPoint[p].title);
-                            for (var aid in storylineList){
-                                if (storylineList[aid].ID == active_id){
-                                    storylineList[aid].path.push(currentPOI.ID);
-                                    break;
-                                }
-                            }
                             spCreated = true;
                         }
                     }


### PR DESCRIPTION
The currentPOI.ID should only be pushed when a new one is made, not
when one is being edited.
