### PR TITLE
NOTASK Attempt dup ID fix

### DIFF
--- a/utilities/js/core/storylines/textEditor.js
+++ b/utilities/js/core/storylines/textEditor.js
@@ -43,6 +43,29 @@ $(document).ready(function(){
         if(active_id == -2){
             if(!_.contains(POIList, currentPOI)){
                 POIList.push(currentPOI);
+                
+                var oldPOT = _.find(POTList, function(item) { return item.ID === currentPOI.ID; });
+
+                //Remove POT it used to be
+                POTList = _.reject(POTList, function(el) { return el === oldPOT; });
+
+                // Replace it in the node list
+                nodeList = _.reject(nodeList, function(el) { return el === oldPOT; });
+                nodeList.push(currentPOI);
+
+                // Replace in the edge list
+                for(var i = 0; i < edgeList.length; i++)
+                {
+                    if(edgeList[i].origin === oldPOT)
+                    {
+                        edgeList[i].origin = currentPOI;
+                    }
+
+                    if(edgeList[i].destination === oldPOT)
+                    {
+                        edgeList[i].destination = currentPOI;
+                    }
+                }
             }
             for(var val in POIList){
                 if(POIList[val].ID === currentPOI.ID){


### PR DESCRIPTION
-Fixed a bug where creating a POI without associating a storypoint would leaving a POT with a conflicting ID. This would cause an issue when reimporting the map as reported by a client